### PR TITLE
feat: add XOR type definition W-18851777

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2024, Salesforce.com, Inc.
+Copyright (c) 2025, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,4 @@ export * from './function';
 export * from './json';
 export * from './mapped';
 export * from './union';
+export * from './xor';

--- a/src/types/xor.ts
+++ b/src/types/xor.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+
+/**
+ * XOR type example:
+ *
+ * ```
+ * interface A {
+ *   name: string;
+ * }
+ *
+ * interface B {
+ *   id: string;
+ * }
+ *
+ * type MyXORType = XOR<A, B>;
+ *
+ * const valid1: MyXORType = { name: 'My_Foo' }; // Valid
+ * const valid2: MyXORType = { id: '0xT0000cxxxeeRGtHM' };    // Valid
+ *
+ * const invalid1: MyXORType = { name: 'hello', id: 123 }; // Error: Object literal may only specify known properties
+ * const invalid2: MyXORType = {}; // Error: Property 'name' or 'id' is missing
+ * ```
+ */
+export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;

--- a/test/xor.test.ts
+++ b/test/xor.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import { XOR } from '../src/types';
+
+describe('XOR', () => {
+  type A = { name: string };
+  type B = { id: string };
+  type NameOrId = XOR<A, B>;
+
+  it('should allow only 1 property from each type', () => {
+    const valid1: NameOrId = { name: 'My_Foo' };
+    const valid2: NameOrId = { id: '0xT0000cxxxeeRGtHM' };
+    expect(valid1).to.deep.equal({ name: 'My_Foo' });
+    expect(valid2).to.deep.equal({ id: '0xT0000cxxxeeRGtHM' });
+
+    // Either of these would cause TypeScript errors during compilation
+    // const invalid1: NameOrId = { name: 'My_Foo', id: '0xT0000cxxxeeRGtHM' };
+    // const invalid2: NameOrId = { };
+  });
+});


### PR DESCRIPTION
Adds a new XOR type definition so that we can define types that behave like this:
  ```
  interface A { name: string; }
  interface B { id: string; }
 
  type MyXORType = XOR<A, B>;
 
  const valid1: MyXORType = { name: 'My_Foo' }; // Valid
  const valid2: MyXORType = { id: '0xT0000cxxxeeRGtHM' };    // Valid
 
  const invalid1: MyXORType = { name: 'My_Foo', id:'0xT0000cxxxeeRGtHM' }; // Error: Object literal may only specify known properties
  const invalid2: MyXORType = {}; // Error: Property 'name' or 'id' is missing
  ```

@W-18851777@